### PR TITLE
Implement std::error::Error for Error

### DIFF
--- a/unhtml/src/err.rs
+++ b/unhtml/src/err.rs
@@ -15,4 +15,6 @@ pub enum Error {
     },
 }
 
+impl std::error::Error for Error {}
+
 pub type Result<T> = std::result::Result<T, Error>;


### PR DESCRIPTION
This makes the `Error` struct easier to use with libraries for error handling. Personally I wanted to use `snafu` in my application but it requires that the source errors implement the error trait.