### PR TITLE
Implement feature to specify default value

### DIFF
--- a/src/html/foo.rs
+++ b/src/html/foo.rs
@@ -1,6 +1,6 @@
 use unhtml::{
     scraper::{Html, Selector},
-    Element, Result, FromHtml
+    Element, FromHtml, Result,
 };
 
 #[derive(FromHtml, Debug, Eq, PartialEq)]

--- a/src/text.rs
+++ b/src/text.rs
@@ -1,6 +1,6 @@
 use std::str::FromStr;
 use unhtml::scraper::{Html, Selector};
-use unhtml::{Text, FromText, Error};
+use unhtml::{Error, FromText, Text};
 
 #[derive(Debug, FromText, Eq, PartialEq)]
 struct U8(u8);


### PR DESCRIPTION
This adds the ability to specify an expression as the default value fallback (as already specified in `README.md`). This implementation is inspired by [`structopt-derive`](https://github.com/TeXitoi/structopt/blob/master/structopt-derive/src/attrs.rs). To be able to parse custom expressions we have to move away from using `Meta` and rather use our own `Parse` implementation, hence there is a bit of rewriting going on here. However this was a really fun PR to make, as it's my first time working with `syn` and `proc_macro`. 