### PR TITLE
Bump scraper to 0.13

### DIFF
--- a/unhtml/Cargo.toml
+++ b/unhtml/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 documentation = "https://docs.rs/unhtml"
 
 [dependencies]
-scraper = { version = "0.12", default-features = false }
+scraper = { version = "0.13", default-features = false }
 derive_more = "0.99"
 unhtml_derive = { path = "../unhtml_derive", version = "0.8", optional = true }
 

--- a/unhtml_derive/Cargo.toml
+++ b/unhtml_derive/Cargo.toml
@@ -18,7 +18,7 @@ proc-macro = true
 syn = { version = "1.0", features = ["full"] }
 proc-macro2 = "1.0"
 quote = "1.0"
-scraper = { version = "0.12", default-features = false }
+scraper = { version = "0.13", default-features = false }
 
 [badges]
 travis-ci = { repository = "Hexilee/unhtml.rs", branch = "master" }


### PR DESCRIPTION
Just bump scraper to new version. It was updated a couple of months ago.
Test cases are passed..